### PR TITLE
Allow for pathnames to be used as filenames

### DIFF
--- a/lib/simple-spreadsheet.rb
+++ b/lib/simple-spreadsheet.rb
@@ -8,8 +8,8 @@ module SimpleSpreadsheet
   class Workbook
 
     def self.read(file, ext = nil)
-      file = file.to_s
-      ext = File.extname(file) if ext.nil?
+      file  = file.to_s
+      ext ||= File.extname(file)
       case ext
       when '.xls'
         return ExcelReader.new(file)

--- a/lib/simple-spreadsheet.rb
+++ b/lib/simple-spreadsheet.rb
@@ -12,19 +12,19 @@ module SimpleSpreadsheet
       ext ||= File.extname(file)
       case ext
       when '.xls'
-        return ExcelReader.new(file)
+        ExcelReader.new(file)
       when '.xlsx'
-        return ExcelxReader.new(file)
+        ExcelxReader.new(file)
       when '.ods'
-        return OpenofficeReader.new(file)
+        OpenofficeReader.new(file)
       when '.csv'
-        return CsvReader.new(file)
+        CsvReader.new(file)
       when '.csvx'
-        return CsvxReader.new(file)
+        CsvxReader.new(file)
       when '.csvt', '.tsv'
-        return CsvtReader.new(file)
+        CsvtReader.new(file)
       else
-        return nil
+        nil
       end
     end
 

--- a/lib/simple-spreadsheet.rb
+++ b/lib/simple-spreadsheet.rb
@@ -8,6 +8,7 @@ module SimpleSpreadsheet
   class Workbook
 
     def self.read(file, ext = nil)
+      file = file.to_s
       ext = File.extname(file) if ext.nil?
       case ext
       when '.xls'

--- a/spec/simple-spreadsheet_spec.rb
+++ b/spec/simple-spreadsheet_spec.rb
@@ -2,6 +2,10 @@
 require 'spec_helper'
 
 describe SimpleSpreadsheet do
-  
-    
+  let(:xls_file)  { File.expand_path '../fixtures/file.xlsx', __FILE__ }
+  let(:file_path) { Pathname.new xls_file }
+
+  it 'allows pathnames as filename argument without raising exception' do
+    expect { SimpleSpreadsheet::Workbook.read(file_path) }.to_not raise_error(NoMethodError)
+  end
 end


### PR DESCRIPTION
Hi there, I realized pathnames were not handled correctly by the gem. If you tried to use a pathname instance as a filename the gem raised an exception similar to 
```ruby
NoMethodError: undefined method `start_with?' for #<Pathname:0x0000010216ab90>
```

This pull request easily fixes the issue ensuring making sure the filename is typecasted to string. 

Best,

Andrea