### PR TITLE
Update roo-xls to v1.1 to prevent deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,22 +3,21 @@ PATH
   specs:
     simple-spreadsheet (0.5.0)
       roo (~> 2.4)
-      roo-xls (~> 1.0)
+      roo-xls (~> 1.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    mini_portile2 (2.1.0)
-    nokogiri (1.6.8)
-      mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    pkg-config (1.1.7)
+    mini_portile2 (2.2.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.0-java)
     rake (10.4.2)
-    roo (2.5.1)
+    roo (2.7.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
-    roo-xls (1.0.0)
+    roo-xls (1.1.0)
       nokogiri
       roo (>= 2.0.0beta1, < 3)
       spreadsheet (> 0.9.0)
@@ -35,9 +34,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    ruby-ole (1.2.12)
-    rubyzip (1.2.0)
-    spreadsheet (1.1.3)
+    ruby-ole (1.2.12.1)
+    rubyzip (1.2.1)
+    spreadsheet (1.1.4)
       ruby-ole (>= 1.0)
 
 PLATFORMS
@@ -51,4 +50,4 @@ DEPENDENCIES
   simple-spreadsheet!
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/simple-spreadsheet.gemspec
+++ b/simple-spreadsheet.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", "~> 10.1"
   gem.add_development_dependency "rspec","~> 3.3"
   gem.add_runtime_dependency "roo", "~> 2.4"
-  gem.add_runtime_dependency "roo-xls", "~> 1.0"
+  gem.add_runtime_dependency "roo-xls", "~> 1.1"
 end


### PR DESCRIPTION
Roo-xls have included a patch to fix the deprecation warning about Roo::Tempdir.
`[DEPRECATION] extend Roo::Tempdir and use its .make_tempdir instead`

This PR bumps the `roo-xls` to v1.1